### PR TITLE
Refactor main character

### DIFF
--- a/godot/project.godot
+++ b/godot/project.godot
@@ -77,11 +77,6 @@ jump={
 2d_physics/layer_5="player hurtbox"
 2d_physics/layer_6="enemy hurtbox"
 
-[physics]
-
-common/physics_ticks_per_second=120
-common/max_physics_steps_per_frame=20
-
 [rendering]
 
 viewport/hdr_2d=true

--- a/rust/src/classes/enemies/test_enemy.rs
+++ b/rust/src/classes/enemies/test_enemy.rs
@@ -1,7 +1,5 @@
 use godot::{
-    classes::{
-        AnimationPlayer, Area2D, CharacterBody2D, ICharacterBody2D, Marker2D, RayCast2D, Timer,
-    },
+    classes::{AnimationPlayer, Area2D, CharacterBody2D, ICharacterBody2D, Marker2D},
     obj::WithBaseField,
     prelude::*,
 };

--- a/rust/src/components/managers/input_hanlder.rs
+++ b/rust/src/components/managers/input_hanlder.rs
@@ -24,37 +24,25 @@ impl InputHandler {
         vel
     }
 
-    pub fn platformer_to_event(input: &Gd<Input>, delta: &f64) -> Event {
-        let mut vel = Vector2::ZERO;
+    pub fn platformer_to_event(input: &Gd<Input>) -> Event {
+        let mut velocity = Vector2::ZERO;
         if input.is_action_pressed("east") {
-            vel += Vector2::RIGHT;
+            velocity += Vector2::RIGHT;
         }
         if input.is_action_pressed("west") {
-            vel += Vector2::LEFT;
+            velocity += Vector2::LEFT;
         }
-        if input.is_action_just_pressed("dodge") && vel.length() > 0.0 {
-            return Event::DodgeButton {
-                velocity: vel,
-                delta: *delta,
-            };
+        if input.is_action_just_pressed("dodge") && velocity.length() > 0.0 {
+            return Event::DodgeButton;
         }
         if input.is_action_just_pressed("attack") {
-            return Event::AttackButton {
-                velocity: vel,
-                delta: *delta,
-            };
+            return Event::AttackButton;
         }
         if input.is_action_just_pressed("jump") {
-            return Event::JumpButton {
-                velocity: vel,
-                delta: *delta,
-            };
+            return Event::JumpButton;
         }
-        if vel.length() > 0.0 {
-            Event::Wasd {
-                velocity: vel,
-                delta: *delta,
-            }
+        if velocity.length() > 0.0 {
+            Event::Wasd { velocity }
         } else {
             Event::None
         }

--- a/rust/src/components/managers/input_hanlder.rs
+++ b/rust/src/components/managers/input_hanlder.rs
@@ -10,21 +10,16 @@ impl InputHandler {
         let mut vel = Vector2::ZERO;
         if input.is_action_pressed("east") {
             vel += Vector2::RIGHT;
-        }
-        if input.is_action_pressed("west") {
+        } else if input.is_action_pressed("west") {
             vel += Vector2::LEFT;
-        }
-        if input.is_action_pressed("north") {
-            vel += Vector2::UP;
-        }
-        if input.is_action_pressed("south") {
-            vel += Vector2::DOWN;
+        } else {
+            vel = Vector2::ZERO;
         }
 
         vel
     }
 
-    pub fn platformer_to_event(input: &Gd<Input>) -> Event {
+    pub fn to_platformer_event(input: &Gd<Input>) -> Event {
         let mut velocity = Vector2::ZERO;
         if input.is_action_pressed("east") {
             velocity += Vector2::RIGHT;
@@ -38,19 +33,18 @@ impl InputHandler {
         if input.is_action_just_pressed("attack") {
             return Event::AttackButton;
         }
-        if input.is_action_just_pressed("jump") {
+        if input.is_action_pressed("jump") {
             return Event::JumpButton;
         }
         if velocity.length() > 0.0 {
-            Event::Wasd { velocity }
+            Event::Wasd
         } else {
             Event::None
         }
     }
 
-    pub fn to_event(input: &Gd<Input>, delta: &f64) -> Event {
+    pub fn to_event(input: &Gd<Input>) -> Event {
         let mut vel = Vector2::ZERO;
-        let delta = delta.to_owned();
         if input.is_action_pressed("east") {
             vel += Vector2::RIGHT;
         }
@@ -64,30 +58,14 @@ impl InputHandler {
             vel += Vector2::DOWN;
         }
         if input.is_action_just_pressed("dodge") && vel.length() > 0.0 {
-            return Event::DodgeButton {
-                velocity: vel.normalized(),
-                delta,
-            };
+            return Event::DodgeButton;
         }
         if input.is_action_just_pressed("attack") {
-            if vel.length() == 0.0 {
-                return Event::AttackButton {
-                    velocity: vel,
-                    delta,
-                };
-            } else {
-                return Event::AttackButton {
-                    velocity: vel.normalized(),
-                    delta,
-                };
-            }
+            return Event::AttackButton;
         }
 
         if vel.length() > 0.0 {
-            Event::Wasd {
-                velocity: vel.normalized(),
-                delta,
-            }
+            Event::Wasd
         } else {
             Event::None
         }

--- a/rust/src/components/state_machines/enemy_state_machine.rs
+++ b/rust/src/components/state_machines/enemy_state_machine.rs
@@ -42,7 +42,7 @@ impl EnemyStateMachine {
     fn idle(event: &EnemyEvent) -> Response<State> {
         match event {
             EnemyEvent::TimerElapsed => Response::Transition(State::patrol()),
-            EnemyEvent::FoundPlayer { player } => Response::Super,
+            EnemyEvent::FoundPlayer { player: _player } => Response::Super,
             _ => Response::Handled,
         }
     }
@@ -51,7 +51,7 @@ impl EnemyStateMachine {
     fn patrol(event: &EnemyEvent) -> Response<State> {
         match event {
             EnemyEvent::TimerElapsed => Response::Transition(State::idle()),
-            EnemyEvent::FoundPlayer { player } => Response::Super,
+            EnemyEvent::FoundPlayer { player: _player } => Response::Super,
             _ => Handled,
         }
     }


### PR DESCRIPTION
Refactors the player character state machine to prevent passing a godot
owned pointer around. The player character now just matches the state of
the state machine and calls the functions for itself.

While there is nothing inherently wrong with passing a Gd<>, it does add
an amount of cognitive overhead in remembering where and when binding
occurs on the pointer. With this PR, we don't have to worry about that
and the borrow checker will ensure borrowing rules are upheld.