### PR TITLE
fix camera shake

### DIFF
--- a/godot/entities/player/main_character.tscn
+++ b/godot/entities/player/main_character.tscn
@@ -3507,5 +3507,10 @@ collide_with_areas = true
 
 [node name="ItemComponent" type="ItemComponent" parent="."]
 
-[node name="RustPlayerCamera" type="Camera2D" parent="."]
+[node name="ShakyPlayerCamera" type="ShakyPlayerCamera" parent="."]
+decay = 0.8
+max_rot = 0.0
+ignore_rotation = false
 process_callback = 0
+drag_horizontal_enabled = true
+drag_vertical_enabled = true

--- a/rust/src/classes/characters/main_character.rs
+++ b/rust/src/classes/characters/main_character.rs
@@ -203,7 +203,7 @@ impl ICharacterBody2D for MainCharacter {
 #[godot_api]
 impl MainCharacter {
     #[signal]
-    pub fn player_damaged(previous_health: u32, new_health: u32, damage_amount: u32);
+    pub fn player_health_changed(previous_health: u32, new_health: u32, damage_amount: u32);
 
     #[signal]
     fn parried_attack();
@@ -445,7 +445,7 @@ impl MainCharacter {
                 self.stats.get_mut(&Stats::Health).unwrap().0 += amount;
                 let new = self.stats.get(&Stats::Health).unwrap().0;
                 self.signals()
-                    .player_damaged()
+                    .player_health_changed()
                     .emit(current_health, new, amount);
             }
             self.timers.reset(&x);
@@ -595,7 +595,7 @@ impl Damageable for MainCharacter {
 
         self.set_health(current_health);
         self.signals()
-            .player_damaged()
+            .player_health_changed()
             .emit(previous_health, current_health, amount);
 
         if self.is_dead() {

--- a/rust/src/components/managers/player_manager.rs
+++ b/rust/src/components/managers/player_manager.rs
@@ -1,7 +1,8 @@
 use godot::prelude::*;
 
 use crate::classes::characters::{
-    main_character::MainCharacter, shaky_player_camera::ShakyPlayerCamera,
+    main_character::MainCharacter,
+    shaky_player_camera::{ShakyPlayerCamera, TraumaLevel},
 };
 
 #[derive(GodotClass)]
@@ -42,13 +43,15 @@ impl PlayerManager {
 
     fn on_player_ready(&mut self) {
         if let Some(player) = &self.player {
-            let camera = player.get_node_as::<ShakyPlayerCamera>("RustPlayerCamera");
-            player
-                .signals()
-                .player_damaged()
-                .connect_other(&camera, |camera, _prev, _new, _am| {
-                    camera.add_trauma(0.4);
-                });
+            let camera = player.get_node_as::<ShakyPlayerCamera>("ShakyPlayerCamera");
+            player.signals().player_health_changed().connect_other(
+                &camera,
+                |camera, prev, new, _am| {
+                    if new < prev {
+                        camera.add_trauma(TraumaLevel::Low);
+                    }
+                },
+            );
         }
     }
 }

--- a/rust/src/components/managers/player_stats_ui_singleton.rs
+++ b/rust/src/components/managers/player_stats_ui_singleton.rs
@@ -23,7 +23,7 @@ impl INode2D for PlayerStatsUIHandler {
 
 impl PlayerStatsUIHandler {
     fn connect_signals(&mut self) {
-        self.player.signals().player_damaged().connect_other(
+        self.player.signals().player_health_changed().connect_other(
             &*self.player_ui,
             |s: &mut HealthBar, previous_health, current_health, amount| {
                 s.on_player_damaged(previous_health, current_health, amount);


### PR DESCRIPTION
Fix camera shake.
Fix node paths.
Add trauma enum.
Rename, yet again, player signal.